### PR TITLE
Fix prototype chain on map objects

### DIFF
--- a/lib/goog.js
+++ b/lib/goog.js
@@ -28,8 +28,8 @@ var parseProvideRequire = function(str) {
 
 var parseDepsJs = function(filepath, content) {
   var parsed = {
-    fileMap: Object.create(null),
-    provideMap: Object.create(null)
+    fileMap: {},
+    provideMap: {}
   };
   var sandbox = {
     parsed: parsed,

--- a/lib/iit.js
+++ b/lib/iit.js
@@ -1,5 +1,5 @@
 var IitFilter = function() {
-  var inclusiveMap = Object.create(null);
+  var inclusiveMap = {};
   var currentMode = 0;
 
   var recomputeCurrentMode = function() {

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -6,8 +6,8 @@ var DependencyResolver = function(logger) {
   var log = logger.create('closure');
 
   // the state
-  var fileMap = Object.create(null);
-  var provideMap = Object.create(null);
+  var fileMap = {};
+  var provideMap = {};
 
   var updateProvideMap = function(filepath, oldProvides, newProvides) {
     oldProvides.forEach(function(dep) {
@@ -100,7 +100,7 @@ var DependencyResolver = function(logger) {
     // console.log(fileMap);
 
     var resolvedFiles = [];
-    var alreadyResolvedMap = Object.create(null);
+    var alreadyResolvedMap = {};
 
     files.forEach(function(file) {
       resolveFile(file, resolvedFiles, alreadyResolvedMap);


### PR DESCRIPTION
As per https://github.com/karma-runner/karma-closure/issues/15, newer versions of Node aren't happy with using `Object.create(null)`. Using `{}` maintains the prototype chain.
